### PR TITLE
create internal public-start command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "webpack serve",
     "prod-start": "node server.js",
     "build-start": "npm run prepare && npm run prod-start",
+    "public-start": "npm run prepare && node server.js 80",
     "lint": "standard",
     "fix": "standard --fix",
     "test": "npm run lint && mocha"

--- a/server.js
+++ b/server.js
@@ -73,6 +73,6 @@ app.all('*', function (req, res, next) {
 })
 
 // Start the server
-const server = app.listen(process.argv[2] == undefined ? 8080 : process.argv[2], function () {
+const server = app.listen(process.argv[2] === undefined ? 8080 : process.argv[2], function () {
   console.log('Server listening on port ' + server.address().port)
 })

--- a/server.js
+++ b/server.js
@@ -73,6 +73,6 @@ app.all('*', function (req, res, next) {
 })
 
 // Start the server
-const server = app.listen(8080, function () {
+const server = app.listen(process.argv[2] == undefined ? 8080 : process.argv[2], function () {
   console.log('Server listening on port ' + server.address().port)
 })


### PR DESCRIPTION
The internal public-start command will be used on the demo server to bind to port 80 instead of port 8080.
closes #48 