### PR TITLE
Adding Game Menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <link rel="manifest" href="manifest.json" crossorigin="use-credentials">
   </head>
   <body>
+    <game-menu id="game-menu" style="display: none;"></game-menu>
     <debug-menu id="debugmenu" style="display: none;"></debug-menu>
     <player-list id="playerlist" style="display: none;"></player-list>
     <cross-hair id="crosshair" style="display: none;"></cross-hair>

--- a/index.js
+++ b/index.js
@@ -200,7 +200,7 @@ async function connect (options) {
   })
 
   bot.once('login', () => {
-    loadingScreen.status = 'Loading world...'
+    loadingScreen.status = 'Loading world'
   })
 
   bot.once('spawn', () => {

--- a/index.js
+++ b/index.js
@@ -306,7 +306,9 @@ async function connect (options) {
       renderer.domElement.mozRequestPointerLock ||
       renderer.domElement.webkitRequestPointerLock
     document.addEventListener('mousedown', (e) => {
-      renderer.domElement.requestPointerLock()
+      if(!chat.inChat) {
+        renderer.domElement.requestPointerLock()
+      }
     })
 
     document.addEventListener('contextmenu', (e) => e.preventDefault(), false)

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 require('./lib/menu')
 require('./lib/loading_screen')
 require('./lib/hotbar')
+require('./lib/gameMenu')
 require('./lib/chat')
 require('./lib/crosshair')
 require('./lib/playerlist')
@@ -135,6 +136,7 @@ async function connect (options) {
   const chat = document.getElementById('chatbox')
   const playerList = document.getElementById('playerlist')
   const debugMenu = document.getElementById('debugmenu')
+  const gameMenu = document.getElementById('game-menu')
 
   const viewDistance = 6
   const hostprompt = options.server
@@ -217,6 +219,7 @@ async function connect (options) {
     const worldView = new WorldView(bot.world, viewDistance, center)
 
     chat.init(bot._client, renderer)
+    gameMenu.init();
     playerList.init(bot)
 
     viewer.setVersion(version)
@@ -306,7 +309,7 @@ async function connect (options) {
       renderer.domElement.mozRequestPointerLock ||
       renderer.domElement.webkitRequestPointerLock
     document.addEventListener('mousedown', (e) => {
-      if(!chat.inChat) {
+      if(!chat.inChat && !gameMenu.inMenu) {
         renderer.domElement.requestPointerLock()
       }
     })
@@ -329,6 +332,7 @@ async function connect (options) {
 
     document.addEventListener('keydown', (e) => {
       if (chat.inChat) return
+      if(gameMenu.inMenu) return
       console.log(e.code)
       if (e.code in codes) {
         bot.setControlState(codes[e.code], true)

--- a/index.js
+++ b/index.js
@@ -219,7 +219,7 @@ async function connect (options) {
     const worldView = new WorldView(bot.world, viewDistance, center)
 
     chat.init(bot._client, renderer)
-    gameMenu.init()
+    gameMenu.init(renderer)
     playerList.init(bot)
 
     viewer.setVersion(version)

--- a/index.js
+++ b/index.js
@@ -219,7 +219,7 @@ async function connect (options) {
     const worldView = new WorldView(bot.world, viewDistance, center)
 
     chat.init(bot._client, renderer)
-    gameMenu.init();
+    gameMenu.init()
     playerList.init(bot)
 
     viewer.setVersion(version)
@@ -309,7 +309,7 @@ async function connect (options) {
       renderer.domElement.mozRequestPointerLock ||
       renderer.domElement.webkitRequestPointerLock
     document.addEventListener('mousedown', (e) => {
-      if(!chat.inChat && !gameMenu.inMenu) {
+      if (!chat.inChat && !gameMenu.inMenu) {
         renderer.domElement.requestPointerLock()
       }
     })
@@ -332,7 +332,7 @@ async function connect (options) {
 
     document.addEventListener('keydown', (e) => {
       if (chat.inChat) return
-      if(gameMenu.inMenu) return
+      if (gameMenu.inMenu) return
       console.log(e.code)
       if (e.code in codes) {
         bot.setControlState(codes[e.code], true)

--- a/lib/chat.js
+++ b/lib/chat.js
@@ -132,6 +132,7 @@ class ChatBox extends LitElement {
 
     // Chat events
     document.addEventListener('keypress', e => {
+      if (gameMenu.inMenu) return;
       e = e || window.event
       if (self.inChat === false) {
         if (e.code === 'KeyT') {

--- a/lib/chat.js
+++ b/lib/chat.js
@@ -116,7 +116,7 @@ class ChatBox extends LitElement {
 
     // Esc event - Doesnt work with onkeypress?!
     document.addEventListener('keydown', e => {
-      if (gameMenu.inMenu) return;
+      if (gameMenu.inMenu) return
       if (!self.inChat) return
       e = e || window.event
       if (e.keyCode === 27 || e.key === 'Escape' || e.key === 'Esc') {
@@ -132,7 +132,7 @@ class ChatBox extends LitElement {
 
     // Chat events
     document.addEventListener('keypress', e => {
-      if (gameMenu.inMenu) return;
+      if (gameMenu.inMenu) return
       e = e || window.event
       if (self.inChat === false) {
         if (e.code === 'KeyT') {

--- a/lib/chat.js
+++ b/lib/chat.js
@@ -99,6 +99,7 @@ class ChatBox extends LitElement {
   init (client, renderer) {
     this.inChat = false
     const chat = this.shadowRoot.querySelector('#chat')
+    const gameMenu = document.getElementById('game-menu')
     const chatInput = this.shadowRoot.querySelector('#chatinput')
 
     const chatHistory = []
@@ -115,6 +116,7 @@ class ChatBox extends LitElement {
 
     // Esc event - Doesnt work with onkeypress?!
     document.addEventListener('keydown', e => {
+      if (gameMenu.inMenu) return;
       if (!self.inChat) return
       e = e || window.event
       if (e.keyCode === 27 || e.key === 'Escape' || e.key === 'Esc') {

--- a/lib/gameMenu.js
+++ b/lib/gameMenu.js
@@ -1,0 +1,132 @@
+const { LitElement, html, css } = require('lit-element')
+require('./github_link')
+require('./components/button')
+require('./components/buttonlink')
+require('./components/textfield')
+
+/* global fetch */
+class GameMenu extends LitElement {
+    constructor() {
+        super()
+        this.inMenu = false;
+    }
+
+    disableGameMenu() {
+        this.inMenu = false
+        this.style.display = 'none'
+        renderer.domElement.requestPointerLock()
+    }
+
+    enableGameMenu() {
+        this.inMenu = true
+        document.exitPointerLock()
+        this.style.display = 'block'
+        this.focus()
+    }
+
+    static get styles() {
+        return css`
+    :host {
+      --guiScale: var(--guiScaleFactor, 3);
+    }
+
+    html {
+      height: 100%;
+    }
+    
+    body {
+      margin:0;
+      padding:0;
+      font-family: sans-serif;
+      background: #000;
+    }
+    
+    .menu-box {
+      position: fixed;
+      z-index: 11;
+      top: 50%;
+      left: 50%;
+      width: calc(180px * var(--guiScale));
+      padding: calc(10px * var(--guiScale));
+      transform: translate(-50%, -50%);
+      box-sizing: border-box;
+      border-radius: 10px;
+      background: rgba(0, 0, 0, 0.8)
+    }
+
+    .link-buttons {
+      display: flex;
+      justify-content: space-between; 
+      gap: calc(4px * var(--guiScale));
+    }
+
+    .title, .subtitle {
+      text-align: center;
+
+      font-family: mojangles, minecraft, monospace;
+      font-size: calc(10px * var(--guiScale));
+      font-weight: normal;
+
+      color: white;
+      margin-top: 0;
+      text-shadow: calc(1px * var(--guiScale)) calc(1px * var(--guiScale)) black;
+    }
+
+    .subtitle {
+      font-size: calc(7.5px * var(--guiScale));
+    }
+
+    .wrapper {
+      display: flex;
+      justify-content: space-between;   
+      gap: calc(6px * var(--guiScale));
+    }
+
+    .spacev {
+      height: calc(6px * var(--guiScale));
+    }
+
+    .field-spacev {
+      height: calc(14px * var(--guiScale));
+    }
+    `
+    }
+
+    render() {
+        return html`
+    <github-link></github-link>
+    <div class="menu-box">
+      <h2 class="title">Game Menu</h2>
+        <div class="spacev"></div>
+        <legacy-button btn-width="100%" @click=${() => { this.disableGameMenu() }}>Back to Game</legacy-button>
+        <div class="spacev"></div>
+        <legacy-button btn-width="100%" onClick="alert('This feature is not available yet!');">Options</legacy-button>
+        <div class="spacev"></div>
+        <legacy-button btn-width="100%" onClick="window.location.reload();">Disconnect</legacy-button>
+    </div>
+    `
+    }
+
+    init () {
+
+        const chat = document.getElementById('chatbox');
+        const self = this
+
+        document.addEventListener('keydown', e => {
+            if (chat.inChat) return;
+            e = e || window.event
+            if (e.keyCode === 27 || e.key === 'Escape' || e.key === 'Esc') {
+                if (self.inMenu) {
+                    self.disableGameMenu();
+                }
+                else {
+                    self.enableGameMenu()
+                }
+            }
+        })
+
+    }
+
+}
+
+window.customElements.define('game-menu', GameMenu)

--- a/lib/gameMenu.js
+++ b/lib/gameMenu.js
@@ -6,26 +6,26 @@ require('./components/textfield')
 
 /* global fetch */
 class GameMenu extends LitElement {
-    constructor() {
-        super()
-        this.inMenu = false;
-    }
+  constructor () {
+    super()
+    this.inMenu = false
+  }
 
-    disableGameMenu() {
-        this.inMenu = false
-        this.style.display = 'none'
-        renderer.domElement.requestPointerLock()
-    }
+  disableGameMenu () {
+    this.inMenu = false
+    this.style.display = 'none'
+    renderer.domElement.requestPointerLock()
+  }
 
-    enableGameMenu() {
-        this.inMenu = true
-        document.exitPointerLock()
-        this.style.display = 'block'
-        this.focus()
-    }
+  enableGameMenu () {
+    this.inMenu = true
+    document.exitPointerLock()
+    this.style.display = 'block'
+    this.focus()
+  }
 
-    static get styles() {
-        return css`
+  static get styles () {
+    return css`
     :host {
       --guiScale: var(--guiScaleFactor, 3);
     }
@@ -90,43 +90,39 @@ class GameMenu extends LitElement {
       height: calc(14px * var(--guiScale));
     }
     `
-    }
+  }
 
-    render() {
-        return html`
+  render () {
+    return html`
     <github-link></github-link>
     <div class="menu-box">
       <h2 class="title">Game Menu</h2>
         <div class="spacev"></div>
         <legacy-button btn-width="100%" @click=${() => { this.disableGameMenu() }}>Back to Game</legacy-button>
         <div class="spacev"></div>
-        <legacy-button btn-width="100%" onClick="alert('This feature is not available yet!');">Options</legacy-button>
+        <legacy-button btn-width="100%">Options</legacy-button>
         <div class="spacev"></div>
         <legacy-button btn-width="100%" onClick="window.location.reload();">Disconnect</legacy-button>
     </div>
     `
-    }
+  }
 
-    init () {
+  init () {
+    const chat = document.getElementById('chatbox')
+    const self = this
 
-        const chat = document.getElementById('chatbox');
-        const self = this
-
-        document.addEventListener('keydown', e => {
-            if (chat.inChat) return;
-            e = e || window.event
-            if (e.keyCode === 27 || e.key === 'Escape' || e.key === 'Esc') {
-                if (self.inMenu) {
-                    self.disableGameMenu();
-                }
-                else {
-                    self.enableGameMenu()
-                }
-            }
-        })
-
-    }
-
+    document.addEventListener('keydown', e => {
+      if (chat.inChat) return
+      e = e || window.event
+      if (e.keyCode === 27 || e.key === 'Escape' || e.key === 'Esc') {
+        if (self.inMenu) {
+          self.disableGameMenu()
+        } else {
+          self.enableGameMenu()
+        }
+      }
+    })
+  }
 }
 
 window.customElements.define('game-menu', GameMenu)

--- a/lib/gameMenu.js
+++ b/lib/gameMenu.js
@@ -4,17 +4,18 @@ require('./components/button')
 require('./components/buttonlink')
 require('./components/textfield')
 
-/* global fetch */
 class GameMenu extends LitElement {
   constructor () {
     super()
     this.inMenu = false
   }
 
-  disableGameMenu () {
+  disableGameMenu (renderer = false) {
     this.inMenu = false
     this.style.display = 'none'
-    renderer.domElement.requestPointerLock()
+    if (renderer) {
+      renderer.domElement.requestPointerLock()
+    }
   }
 
   enableGameMenu () {
@@ -107,7 +108,7 @@ class GameMenu extends LitElement {
     `
   }
 
-  init () {
+  init (renderer) {
     const chat = document.getElementById('chatbox')
     const self = this
 
@@ -116,7 +117,7 @@ class GameMenu extends LitElement {
       e = e || window.event
       if (e.keyCode === 27 || e.key === 'Escape' || e.key === 'Esc') {
         if (self.inMenu) {
-          self.disableGameMenu()
+          self.disableGameMenu(renderer)
         } else {
           self.enableGameMenu()
         }


### PR DESCRIPTION

This pull request is for adding a game menu.

The game menu looks as follows:
[here](https://imgur.com/a/obgC9MM)

It is opened by pressing escape, often the player will have to press escape twice as when the user is in mouse lock it doesn't register as a key press, I do not see this as a major problem and I guess it's just a disadvantage of having it in the browser. I did consider doing something with the mouse lock toggle event.

Options is not completed right now, my plan for that is to add the ability to edit controls and save the player's preferences in local storage but didn't want to go ahead with that until I have you guys approval.

Disconnect simply refreshes the page to let the player join a new server or rejoin.

I tried to use the same style as everything else I could find, this is my first ever attempt at contributing to an open source project. So yeah, I'm open to feedback!
![GameMenu](https://user-images.githubusercontent.com/66561610/113603624-1174bf00-963c-11eb-8b3d-865ea44adfff.PNG)

