### PR TITLE
Make dev builds faster

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "path-browserify": "^1.0.1",
     "prismarine-viewer": "^1.20.0",
     "process": "PrismarineJS/node-process",
-    "speed-measure-webpack-plugin": "^1.5.0",
     "standard": "^16.0.3",
     "stream-browserify": "^3.0.0",
     "three": "^0.127.0",

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,6 +1,3 @@
-const SpeedMeasurePlugin = require('speed-measure-webpack-plugin') // TODO: Remove
-const smp = new SpeedMeasurePlugin()
-
 const { merge } = require('webpack-merge')
 const common = require('./webpack.common.js')
 const CopyPlugin = require('copy-webpack-plugin')
@@ -34,7 +31,7 @@ class SymlinkPlugin {
   }
 }
 
-module.exports = smp.wrap(merge(common, {
+module.exports = merge(common, {
   mode: 'development',
   devtool: 'inline-source-map',
   cache: true,
@@ -49,4 +46,4 @@ module.exports = smp.wrap(merge(common, {
     new CopyPlugin({ patterns: common[Symbol.for('webpack_files')] }),
     new SymlinkPlugin({ directories: common[Symbol.for('webpack_directories')] })
   ]
-}))
+})

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,6 +1,3 @@
-const SpeedMeasurePlugin = require('speed-measure-webpack-plugin') // TODO: Remove
-const smp = new SpeedMeasurePlugin()
-
 const { merge } = require('webpack-merge')
 const common = require('./webpack.common.js')
 
@@ -10,7 +7,7 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const webpack = require('webpack')
 const WorkboxPlugin = require('workbox-webpack-plugin')
 
-module.exports = smp.wrap(merge(common, {
+module.exports = merge(common, {
   mode: 'production',
   plugins: [
     new CleanWebpackPlugin(),
@@ -30,4 +27,4 @@ module.exports = smp.wrap(merge(common, {
       include: ['index.html', 'manifest.json'] // not caching a lot as anyway this works only online
     })
   ]
-}))
+})


### PR DESCRIPTION
Closes #210

What changed:
- `webpack.common.js` now exposes `Symbol(webpack_directories)` and `Symbol(webpack_files)` fields, instead of just copying everything (which is pretty slow)
- `webpack.dev.js` uses own `SymlinkPlugin` to symlink directories listed in `Symbol(webpack_directories)`
- GenerateSW plugin moved to `webpack.prod.js`, since Workbox is disabled in development mode anyway