### PR TITLE
[chore] Pin three @ v0.127.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "process": "PrismarineJS/node-process",
     "standard": "^16.0.3",
     "stream-browserify": "^3.0.0",
-    "three": "^0.127.0",
+    "three": "0.127.0",
     "timers-browserify": "^2.0.12",
     "webpack": "^5.11.0",
     "webpack-cli": "^4.2.0",


### PR DESCRIPTION
Anything above 0.127.0 breaks the entire app.