### PR TITLE
Fix bug of being able to access slots outside of the 1-9 range

### DIFF
--- a/index.js
+++ b/index.js
@@ -343,6 +343,7 @@ async function connect (options) {
       }
       if (e.code.startsWith('Digit')) {
         const numPressed = e.code.substr(5)
+        if (numPressed < 1 || numPressed > 9) return
         hotbar.reloadHotbarSelected(numPressed - 1)
       }
       if (e.code === 'KeyQ') {


### PR DESCRIPTION
This PR is to fix a bug where by pressing the key `0`, a user could make the web client render slots outside of the 1-9 range. (slot 0, which doesn't exist, or at least from an end user perspective it doesn't exist)

Recreating the bug is simple, simply press the `0` key. 
As shown below it can then show a slot outside of the hotbar:
![image](https://user-images.githubusercontent.com/66561610/140615400-100574bf-528b-41da-a385-25505c9c3c63.png)
This PR checks that all number keys pressed are between 1-9 for them to be registered.