### PR TITLE
Capitalize "Minecraft" in the bottom info in the title screen

### DIFF
--- a/lib/menus/title_screen.js
+++ b/lib/menus/title_screen.js
@@ -115,7 +115,7 @@ class TitleScreen extends LitElement {
 
       <div class="bottom-info">
         <span>Prismarine Web Client</span>
-        <span>A minecraft client in the browser!</span>
+        <span>A Minecraft client in the browser!</span>
       </div>
     `
   }


### PR DESCRIPTION
The bottom right of the title screen says "A minecraft client in the browser!", but the M in Minecraft should be capitalized.