### PR TITLE
Fix hotbar not working on spawn

### DIFF
--- a/lib/menus/hud.js
+++ b/lib/menus/hud.js
@@ -212,6 +212,7 @@ class Hud extends LitElement {
     debugMenu.bot = bot
 
     chat.init(bot._client, renderer)
+    hotbar.init()
     bot.on('spawn', () => playerList.init(bot, host))
 
     bot.on('entityHurt', (entity) => {
@@ -260,7 +261,6 @@ class Hud extends LitElement {
       healthbar.updateHealth(bot.health)
       foodbar.updateHunger(bot.food)
       // breathbar.updateOxygen(bot.oxygenLevel ?? 20)
-      hotbar.init()
     })
 
     if (document.getElementById('options-screen').forceMobileControls || isMobile()) {


### PR DESCRIPTION
Currently hotbar fails to initialize on first spawn and instead of items, question mark icons are displayed.

This PR attempts to fix this issue by initializing hotbar earlier.