### PR TITLE
Should show error screen on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,6 +182,11 @@ async function connect (options) {
   }, {
     signal: errorAbortController
   })
+  window.addEventListener('error', (e) => {
+    handleError(e.message)
+  }, {
+    signal: errorAbortController.signal
+  })
   const bot = mineflayer.createBot({
     host,
     port,

--- a/index.js
+++ b/index.js
@@ -200,7 +200,7 @@ async function connect (options) {
     loadingScreen.status = `Error encountered. Error message: ${err}. Please reload the page`
     loadingScreen.style = 'display: block;'
     loadingScreen.hasError = true
-  };
+  }
   bot.on('error', handleError)
 
   bot.on('kicked', (kickReason) => {

--- a/index.js
+++ b/index.js
@@ -176,6 +176,12 @@ async function connect (options) {
 
   loadingScreen.status = 'Logging in'
 
+  const errorAbortController = new AbortController()
+  window.addEventListener('unhandledrejection', (e) => {
+    handleError(e.reason)
+  }, {
+    signal: errorAbortController
+  })
   const bot = mineflayer.createBot({
     host,
     port,
@@ -189,12 +195,13 @@ async function connect (options) {
   })
   hud.preload(bot)
 
-  bot.on('error', (err) => {
+  const handleError = (err) => {
     console.log('Encountered error!', err)
     loadingScreen.status = `Error encountered. Error message: ${err}. Please reload the page`
     loadingScreen.style = 'display: block;'
     loadingScreen.hasError = true
-  })
+  };
+  bot.on('error', handleError)
 
   bot.on('kicked', (kickReason) => {
     console.log('User was kicked!', kickReason)
@@ -398,6 +405,9 @@ async function connect (options) {
     hud.style.display = 'block'
 
     setTimeout(function () {
+      // game in playable state show errors in console instead
+      errorAbortController.abort()
+      if (loadingScreen.hasError) return
       // remove loading screen, wait a second to make sure a frame has properly rendered
       loadingScreen.style = 'display: none;'
     }, 2500)

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A minecraft client running in a browser",
   "main": "index.js",
   "scripts": {
+    "postinstall": "node scripts/patchPackages.js",
     "build": "webpack --config webpack.prod.js",
     "build-dev": "webpack --config webpack.dev.js",
     "start": "node --max-old-space-size=8192 server.js 8080 dev",

--- a/scripts/patchPackages.js
+++ b/scripts/patchPackages.js
@@ -1,4 +1,4 @@
-//@ts-check
+// @ts-check
 const path = require('path')
 const dataPath = path.join(require.resolve('minecraft-data'), '../data.js')
 
@@ -15,8 +15,8 @@ function removeLinesBetween (start, end) {
   if (startIndex === -1) return
   const endIndex = startIndex + lines.slice(startIndex).findIndex(line => line === end)
   // insert block comments
-  lines.splice(startIndex, 0, `/*`)
-  lines.splice(endIndex + 2, 0, `*/`)
+  lines.splice(startIndex, 0, '/*')
+  lines.splice(endIndex + 2, 0, '*/')
 }
 
 removeLinesBetween("  'bedrock': {", '  }')

--- a/scripts/patchPackages.js
+++ b/scripts/patchPackages.js
@@ -1,0 +1,25 @@
+//@ts-check
+const path = require('path')
+const dataPath = path.join(require.resolve('minecraft-data'), '../data.js')
+
+const fs = require('fs')
+
+const lines = fs.readFileSync(dataPath, 'utf8').split('\n')
+if (lines[0] === '//patched') {
+  console.log('Already patched')
+  process.exit(0)
+}
+
+function removeLinesBetween (start, end) {
+  const startIndex = lines.findIndex(line => line === start)
+  if (startIndex === -1) return
+  const endIndex = startIndex + lines.slice(startIndex).findIndex(line => line === end)
+  // insert block comments
+  lines.splice(startIndex, 0, `/*`)
+  lines.splice(endIndex + 2, 0, `*/`)
+}
+
+removeLinesBetween("  'bedrock': {", '  }')
+
+lines.unshift('//patched')
+fs.writeFileSync(dataPath, lines.join('\n'), 'utf8')


### PR DESCRIPTION
With this, it should show the error screen when an error actually happens (right now `setTimeout` seems to be removing it).

Though in my fork I've rewritten the error screen so it's now possible to go back without having to reload the page. But I've also rewritten the screen history management, so I don't think I'll ever have time to cherry-pick so many commits, so I'm providing a simpler copy-paste solution for now.