### PR TITLE
The vm has been removed from Webpack 5.

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -26,6 +26,7 @@ const config = {
     },
     fallback: {
       jose: false,
+      "vm": require.resolve("vm-browserify"),
       zlib: require.resolve('browserify-zlib'),
       stream: require.resolve('stream-browserify'),
       buffer: require.resolve('buffer/'),


### PR DESCRIPTION
The problem is due to the absence of the vm module, which used to be automatically included in Webpack 4, but was removed in Webpack 5.